### PR TITLE
cert: avoid panics on nil certs

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -18,6 +18,9 @@ type certificateValue struct {
 
 // String implements flag.Value.String.
 func (v certificateValue) String() string {
+	if v.dst == nil {
+		return ""
+	}
 	return string(pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: v.dst.Raw,


### PR DESCRIPTION
An unhandled panic is happening if `String` is called while certificate is still `nil`