### PR TITLE
*: fix ecdsa public key failing when no values

### DIFF
--- a/bytes_test.go
+++ b/bytes_test.go
@@ -145,3 +145,21 @@ func TestBytesFile(t *testing.T) {
 		t.Errorf("expected %q, got '%X'", bytesFile, fb)
 	}
 }
+
+func TestBytesHexVar(t *testing.T) {
+	var b []byte
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(BytesHex(&b, nil), "hex", "hex data")
+}
+
+func TestBytesBase64Var(t *testing.T) {
+	var b []byte
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(BytesBase64(&b, nil), "base64", "base64 data")
+}
+
+func TestBytesFileVar(t *testing.T) {
+	var b []byte
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(BytesFile(&b, ""), "file", "file data")
+}

--- a/cert_test.go
+++ b/cert_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"reflect"
 	"testing"
@@ -199,4 +200,28 @@ qgNGqQ==
 	if !reflect.DeepEqual(gotCert, expectedCert) {
 		t.Fatalf("got: %v, expected %v", gotCert, expectedCert)
 	}
+}
+
+func TestCertificateVar(t *testing.T) {
+	var cert x509.Certificate
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(Certificate(&cert), "cert", "certificate")
+}
+
+func TestCertificatesVar(t *testing.T) {
+	var certs []*x509.Certificate
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(Certificates(&certs), "certs", "certificates")
+}
+
+func TestCertPoolVar(t *testing.T) {
+	var certPool x509.CertPool
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(CertPool(&certPool), "cert-pool", "certificate pool")
+}
+
+func TestTLSCertificateVar(t *testing.T) {
+	var tlsCert tls.Certificate
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(TLSCertificate(&tlsCert), "tls-cert", "TLS certificate")
 }

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -56,6 +56,9 @@ type ecdsaPublicKeyValue struct {
 
 // String implements flag.Value.String.
 func (v ecdsaPublicKeyValue) String() string {
+	if v.dst == nil || (*v.dst == ecdsa.PublicKey{}) {
+		return ""
+	}
 	publicKeyDer, _ := x509.MarshalPKIXPublicKey(v.dst)
 	return string(pem.EncodeToMemory(&pem.Block{
 		Type:  "PUBLIC KEY",

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"flag"
 	"reflect"
 	"testing"
 )
@@ -43,4 +44,16 @@ Yh0aD0NY2qZxSALwbsuNXZMlELIrWAret2yxju6fMs2Jg7vhcoH++MfgRw==
 	if !reflect.DeepEqual(gotPub, *expectedPub.(*ecdsa.PublicKey)) {
 		t.Fatalf("got: %v, expected %v", gotPub, expectedPub)
 	}
+}
+
+func TestECDSAPublicKeyVar(t *testing.T) {
+	var pub ecdsa.PublicKey
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(ECDSAPublicKey(&pub), "public-key", "public key")
+}
+
+func TestECDSAPrivateKeyVar(t *testing.T) {
+	var priv ecdsa.PrivateKey
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(ECDSAPrivateKey(&priv), "private-key", "private key")
 }

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"flag"
 	"reflect"
 	"testing"
 )
@@ -70,4 +71,16 @@ VQIDAQAB
 	if !reflect.DeepEqual(gotPub, *expectedPub.(*rsa.PublicKey)) {
 		t.Fatalf("got: %v, expected %v", gotPub, expectedPub)
 	}
+}
+
+func TestRSAPublicKeyVar(t *testing.T) {
+	var pub rsa.PublicKey
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(RSAPublicKey(&pub), "public-key", "public key")
+}
+
+func TestRSAPrivateKeyVar(t *testing.T) {
+	var priv rsa.PrivateKey
+	fs := flag.NewFlagSet("test", flag.ExitOnError)
+	fs.Var(RSAPrivateKey(&priv), "private-key", "private key")
 }


### PR DESCRIPTION
Added tests to verify that calls to `flagset.Var` don't fail.